### PR TITLE
Change type annotation from `list` to `Sequence`

### DIFF
--- a/rstream/compression.py
+++ b/rstream/compression.py
@@ -7,7 +7,7 @@ import gzip
 from collections import defaultdict
 from dataclasses import dataclass
 from enum import Enum
-from typing import TypeVar
+from typing import Sequence, TypeVar
 
 from .amqp import _MessageProtocol
 from .utils import RawMessage
@@ -25,7 +25,7 @@ class CompressionType(Enum):
 
 class ICompressionCodec(abc.ABC):
     @abc.abstractmethod
-    def compress(self, messages: list[MessageT]):
+    def compress(self, messages: Sequence[MessageT]):
         pass
 
     @abc.abstractmethod
@@ -60,7 +60,7 @@ class NoneCompressionCodec(ICompressionCodec):
     message_count: int = 0
     buffer: bytes = bytes()
 
-    def compress(self, messages: list[MessageT]):
+    def compress(self, messages: Sequence[MessageT]):
         uncompressed_data = bytes()
         for item in messages:
             msg = RawMessage(item) if isinstance(item, bytes) else item
@@ -99,7 +99,7 @@ class GzipCompressionCodec(ICompressionCodec):
     message_count: int = 0
     buffer: bytes = bytes()
 
-    def compress(self, messages: list[MessageT]):
+    def compress(self, messages: Sequence[MessageT]):
         uncompressed_data = bytes()
         for item in messages:
             msg = RawMessage(item) if isinstance(item, bytes) else item
@@ -152,7 +152,7 @@ class StreamCompressionCodecs:
 
 class CompressionHelper:
     @staticmethod
-    def compress(messages: list[MessageT], compression_type: CompressionType) -> ICompressionCodec:
+    def compress(messages: Sequence[MessageT], compression_type: CompressionType) -> ICompressionCodec:
         codec = StreamCompressionCodecs.get_compression_codec(compression_type=compression_type)
         codec.compress(messages=messages)
         return codec

--- a/rstream/producer.py
+++ b/rstream/producer.py
@@ -19,6 +19,7 @@ from typing import (
     Generic,
     NoReturn,
     Optional,
+    Sequence,
     TypeVar,
     Union,
 )
@@ -291,7 +292,7 @@ class Producer:
     async def send_batch(
         self,
         stream: str,
-        batch: list[MessageT],
+        batch: Sequence[MessageT],
         publisher_name: Optional[str] = None,
         on_publish_confirm: Optional[CB[ConfirmationStatus]] = None,
     ) -> list[int]:
@@ -311,7 +312,7 @@ class Producer:
     async def _send_batch(
         self,
         stream: str,
-        batch: list[MessageT],
+        batch: Sequence[MessageT],
         publisher_name: Optional[str] = None,
         callback: Optional[CB[ConfirmationStatus]] = None,
         sync: bool = True,
@@ -575,7 +576,7 @@ class Producer:
     async def send_sub_entry(
         self,
         stream: str,
-        sub_entry_messages: list[MessageT],
+        sub_entry_messages: Sequence[MessageT],
         compression_type: CompressionType = CompressionType.No,
         publisher_name: Optional[str] = None,
         on_publish_confirm: Optional[CB[ConfirmationStatus]] = None,


### PR DESCRIPTION
Change type annotation from `list` to `Sequence` in `send_batch` and `send_sub_entry` methods to make variable covariant https://mypy.readthedocs.io/en/stable/generics.html#variance-of-generic-types