### PR TITLE
Fix for re-applying subscription filter on reconnect

### DIFF
--- a/rstream/consumer.py
+++ b/rstream/consumer.py
@@ -64,6 +64,7 @@ class _Subscriber:
     decoder: Callable[[bytes], Any]
     offset_type: OffsetType
     offset: int
+    filter_input: Optional[FilterConfiguration]
 
 
 class Consumer:
@@ -188,6 +189,7 @@ class Consumer:
         decoder: Optional[Callable[[bytes], Any]],
         offset_type: OffsetType,
         offset: Optional[int],
+        filter_input: Optional[FilterConfiguration],
     ) -> _Subscriber:
         logger.debug("_create_subscriber(): Create subscriber")
         client = await self._get_or_create_client(stream)
@@ -207,6 +209,7 @@ class Consumer:
             decoder=decoder,
             offset_type=offset_type,
             offset=offset or 0,
+            filter_input=filter_input,
         )
         return subscriber
 
@@ -238,6 +241,7 @@ class Consumer:
                 decoder=decoder,
                 offset_type=offset_specification.offset_type,
                 offset=offset_specification.offset,
+                filter_input=filter_input,
             )
 
             await subscriber.client.run_queue_listener_task(
@@ -520,6 +524,7 @@ class Consumer:
                     callback=curr_subscriber.callback,
                     decoder=curr_subscriber.decoder,
                     offset_specification=offset_specification,
+                    filter_input=curr_subscriber.filter_input,
                 )
             )
 

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -983,6 +983,70 @@ async def test_consume_filtering_match_unfiltered(
     await wait_for(lambda: len(captured) == 0)
 
 
+async def test_consume_filtering_with_reconnect(stream, producer_with_filtering: Producer):
+    publishing_done = asyncio.Event()
+    connection_broke = asyncio.Event()
+
+    async def task_to_publish_messages(connection_broke, producer):
+        for id in ("one", "two", "three", "four", "five"):
+            messages = []
+
+            if id == "three":
+                await connection_broke.wait()
+
+            for _ in range(50):
+                application_properties = {
+                    "id": id,
+                }
+                amqp_message = AMQPMessage(
+                    body="hello: {}".format(id),
+                    application_properties=application_properties,
+                )
+                messages.append(amqp_message)
+            # send_batch is synchronous. will wait till termination
+            await producer_with_filtering.send_batch(stream=stream, batch=messages)  # type: ignore
+        publishing_done.set()
+
+    async def on_connection_closed(disconnection_info):
+        # avoiding multiple connection closed to hit
+        if connection_broke.is_set():
+            return None
+
+        for disconnected_stream in disconnection_info.streams:
+            await consumer.reconnect_stream(disconnected_stream)
+
+        connection_broke.set()
+
+    consumer = Consumer(
+        host="localhost",
+        port=5552,
+        vhost="/",
+        username="guest",
+        password="guest",
+        connection_name="test-connection",
+        on_close_handler=on_connection_closed,
+    )
+
+    captured: list[bytes] = []
+    async def on_message(msg: AMQPMessage, message_context: MessageContext):
+        captured.append(bytes(msg))
+
+    asyncio.create_task(task_to_publish_messages(connection_broke, producer_with_filtering))
+    asyncio.create_task(task_to_delete_connection("test-connection"))
+    await consumer.subscribe(
+        stream=stream,
+        callback=on_message,
+        filter_input=FilterConfiguration(
+            values_to_filter=["two"],
+            match_unfiltered=False,
+        ),
+    )
+
+    await publishing_done.wait()
+    await asyncio.sleep(1)
+    assert len(captured) == 50
+
+
 async def test_consumer_metadata_update(consumer: Consumer) -> None:
     consumer_closed = False
     stream_disconnected = None

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -1028,6 +1028,7 @@ async def test_consume_filtering_with_reconnect(stream, producer_with_filtering:
     )
 
     captured: list[bytes] = []
+
     async def on_message(msg: AMQPMessage, message_context: MessageContext):
         captured.append(bytes(msg))
 


### PR DESCRIPTION
When the reconnect_stream function runs a subscriber is recreated with the existing subscriber setup. This did not include the original filter configuration leading to the filtering quietly disappearing on reconnect.

Added filter_input to the `_Subscriber` object to track this configuration and passed to the `create_subscriber` during `reconnect_stream`

We have concurrent consumers of a single stream that are using a `topic` application-header to subscribe to certain events. After network errors these consumers lose both client and server-side filter configuration which causes events to be consumed incorrectly.
