### PR TITLE
Fix encoding long values with AMQP 1.0 encoder.

### DIFF
--- a/rstream/_pyamqp/_encode.py
+++ b/rstream/_pyamqp/_encode.py
@@ -32,6 +32,7 @@ from typing import (
 from typing_extensions import Buffer
 
 from . import performatives
+from .constants import INT32_MIN, INT32_MAX
 from .message import Message
 from .types import (
     TYPE,
@@ -792,7 +793,7 @@ def encode_unknown(output: bytearray, value: Optional[object], **kwargs: Any) ->
         encode_double(output, value, **kwargs)
     elif isinstance(value, int):
         # if the value fits within AMQP 1.0 32-bit signed integer bounds, encode as an int
-        if -2_147_483_648 <= value <= 2_147_483_647:
+        if INT32_MIN <= value <= INT32_MAX:
             encode_int(output, value, **kwargs)
         else:  # otherwise, we'll assume it fits in a 64-bit long
             encode_long(output, value, **kwargs)

--- a/rstream/_pyamqp/_encode.py
+++ b/rstream/_pyamqp/_encode.py
@@ -32,7 +32,7 @@ from typing import (
 from typing_extensions import Buffer
 
 from . import performatives
-from .constants import INT32_MIN, INT32_MAX
+from .constants import INT32_MAX, INT32_MIN
 from .message import Message
 from .types import (
     TYPE,

--- a/rstream/_pyamqp/_encode.py
+++ b/rstream/_pyamqp/_encode.py
@@ -791,7 +791,11 @@ def encode_unknown(output: bytearray, value: Optional[object], **kwargs: Any) ->
     elif isinstance(value, float):
         encode_double(output, value, **kwargs)
     elif isinstance(value, int):
-        encode_int(output, value, **kwargs)
+        # if the value fits within AMQP 1.0 32-bit signed integer bounds, encode as an int
+        if -2_147_483_648 <= value <= 2_147_483_647:
+            encode_int(output, value, **kwargs)
+        else:  # otherwise, we'll assume it fits in a 64-bit long
+            encode_long(output, value, **kwargs)
     elif isinstance(value, datetime):
         encode_timestamp(output, value, **kwargs)
     elif isinstance(value, list):

--- a/rstream/_pyamqp/constants.py
+++ b/rstream/_pyamqp/constants.py
@@ -69,9 +69,9 @@ MAX_CHANNELS = 65535
 INCOMING_WINDOW = 64 * 1024
 OUTGOING_WINDOW = 64 * 1024
 
-#: Lower and upper bounds for a 32-bit integer. This is used to be able to differentiate between 32-bit int and
-#: 64-bit long values. It is ambiguous at encoding time when using type-checking alone to determine how to encode
-#: the value because python 3 does not differentiate between those int and long types.
+#: Lower and upper bounds for a signed 32-bit integer. This is used to be able to differentiate between 32-bit int
+#: and 64-bit long values. It is ambiguous at encoding time when using type-checking alone to determine how to
+#: encode the value because python 3 does not differentiate between int and long types.
 INT32_MIN = -2_147_483_648
 INT32_MAX = 2_147_483_647
 

--- a/rstream/_pyamqp/constants.py
+++ b/rstream/_pyamqp/constants.py
@@ -69,6 +69,12 @@ MAX_CHANNELS = 65535
 INCOMING_WINDOW = 64 * 1024
 OUTGOING_WINDOW = 64 * 1024
 
+#: Lower and upper bounds for a 32-bit integer. This is used to be able to differentiate between 32-bit int and
+#: 64-bit long values. It is ambiguous at encoding time when using type-checking alone to determine how to encode
+#: the value because python 3 does not differentiate between those int and long types.
+INT32_MIN = -2_147_483_648
+INT32_MAX = 2_147_483_647
+
 DEFAULT_LINK_CREDIT = 10000
 
 FIELD = namedtuple("FIELD", "name, type, mandatory, default, multiple")


### PR DESCRIPTION
Adjusted integer encoding in `encode_unknown()` to encode a python int as either an int or long depending on whether the value is within range of AMQP 1.0 standard 32-bit signed integer.

This should address Issue #212 in a way that is more suitable than the solution from PR #214 . While I won't say it's the prettiest thing, at least it preserves proper encoding of int and long types to comply with AMQP 1.0. 