### PR TITLE
Refactor the producers list replace the reference with the id as map key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ local*
 .githooks/
 .venv/
 .DS_Store
+local_ex

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ __pycache__/
 local*
 .githooks/
 .venv/
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,15 @@ format:
 	poetry run flake8 --exclude=venv,local_tests,docs/examples --max-line-length=120 --ignore=E203,W503,E701,E704
 	poetry run mypy .
 
+rabbitmq-ha-proxy:
+	cd compose/ha_tls; rm -rf tls-gen;
+	cd compose/ha_tls; git clone https://github.com/michaelklishin/tls-gen tls-gen; cd tls-gen/basic; make
+	mv compose/ha_tls/tls-gen/basic/result/server_*_certificate.pem compose/ha_tls/tls-gen/basic/result/server_certificate.pem
+	mv compose/ha_tls/tls-gen/basic/result/server_*key.pem compose/ha_tls/tls-gen/basic/result/server_key.pem
+	cd compose/ha_tls; docker build -t haproxy-rabbitmq-cluster  .
+	cd compose/ha_tls; docker compose down
+	cd compose/ha_tls; docker compose up
+
 test: format
 	poetry run pytest .
 help:

--- a/compose/.gitignore
+++ b/compose/.gitignore
@@ -1,0 +1,6 @@
+tls-gen/
+.DS_Store
+ha_tls/data0
+ha_tls/data1
+ha_tls/data2
+ha_tls/tls-gen

--- a/compose/README.md
+++ b/compose/README.md
@@ -1,0 +1,31 @@
+RabbitMQ cluster with HA proxy 
+===
+
+how to run:
+
+```bash
+git clone git@github.com:rabbitmq/rabbitmq-stream-go-client.git .
+make rabbitmq-ha-proxy 
+```
+
+ports:
+```
+ - localhost:5553 #standard stream port
+ - localhost:5554 #TLS stream port
+ - http://localhost:15673 #management port
+```
+
+RabbitMQ single node with TLS
+===
+
+```bash
+git clone git@github.com:rabbitmq/rabbitmq-stream-go-client.git .
+make rabbitmq-server-tls 
+```
+
+ports:
+```
+ - localhost:5552 #standard stream port
+ - localhost:5551 #TLS stream port
+ - http://localhost:15672 #management port
+```

--- a/compose/ha_tls/Dockerfile
+++ b/compose/ha_tls/Dockerfile
@@ -1,0 +1,3 @@
+FROM haproxy:2.2.22
+
+COPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg

--- a/compose/ha_tls/conf/enabled_plugins
+++ b/compose/ha_tls/conf/enabled_plugins
@@ -1,0 +1,1 @@
+[rabbitmq_management, rabbitmq_stream, rabbitmq_stream_management].

--- a/compose/ha_tls/conf/rabbitmq.conf
+++ b/compose/ha_tls/conf/rabbitmq.conf
@@ -1,0 +1,14 @@
+cluster_formation.peer_discovery_backend  = rabbit_peer_discovery_classic_config
+
+cluster_formation.classic_config.nodes.1 = rabbit@node0
+cluster_formation.classic_config.nodes.2 = rabbit@node1
+cluster_formation.classic_config.nodes.3 = rabbit@node2
+loopback_users.guest = false
+
+ssl_options.cacertfile = /certs/ca_certificate.pem
+ssl_options.certfile = /certs/server_certificate.pem
+ssl_options.keyfile = /certs/server_key.pem
+listeners.ssl.default = 5671
+stream.listeners.ssl.default = 5551
+ssl_options.verify               = verify_peer
+ssl_options.fail_if_no_peer_cert = false

--- a/compose/ha_tls/docker-compose.yml
+++ b/compose/ha_tls/docker-compose.yml
@@ -1,0 +1,69 @@
+version: "3"
+services:
+  rabbit_node0:
+    environment:
+      - RABBITMQ_ERLANG_COOKIE='secret_cookie'
+      - RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=-rabbitmq_stream advertised_host node0 advertised_port 5562
+    networks:
+      - back
+    hostname: node0
+    image: rabbitmq:4-management
+    pull_policy: always
+    ports:
+      - "5561:5551"
+      - "5562:5552"
+      - "5682:5672"
+    tty: true
+    volumes:
+     - ./conf/:/etc/rabbitmq/
+     - "./tls-gen/basic/result/:/certs"
+     - ./data0/:/var/lib/rabbitmq/
+  rabbit_node1:
+    environment:
+      - RABBITMQ_ERLANG_COOKIE='secret_cookie'
+      - RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=-rabbitmq_stream advertised_host node1 advertised_port 5572
+    networks:
+      - back
+    hostname: node1
+    image: rabbitmq:4-management
+    pull_policy: always
+    ports:
+      - "5571:5551"
+      - "5572:5552"
+      - "5692:5672"
+    tty: true
+    volumes:
+      - ./conf/:/etc/rabbitmq/
+      - "./tls-gen/basic/result/:/certs"
+      - ./data1/:/var/lib/rabbitmq/
+  rabbit_node2:
+    environment:
+      - RABBITMQ_ERLANG_COOKIE='secret_cookie'
+      - RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=-rabbitmq_stream advertised_host node2 advertised_port 5582
+    networks:
+      - back
+    hostname: node2
+    image: rabbitmq:4-management
+    pull_policy: always
+    ports:
+      - "5581:5551"
+      - "5582:5552"
+      - "5602:5672"
+    tty: true
+    volumes:
+      - ./conf/:/etc/rabbitmq/
+      - "./tls-gen/basic/result/:/certs"
+      - ./data2/:/var/lib/rabbitmq/
+  haproxy:
+    image: haproxy-rabbitmq-cluster
+#    container_name: haproxy
+    hostname: haproxy
+    ports:
+      - "5553:5552"
+      - "5554:5551"
+      - "5674:5672"
+      - "15673:15672"
+    networks:
+      - back
+networks:
+  back:

--- a/compose/ha_tls/haproxy.cfg
+++ b/compose/ha_tls/haproxy.cfg
@@ -1,0 +1,42 @@
+global
+    maxconn 4096
+
+defaults
+    timeout connect 60s
+    timeout client 60s
+    timeout server 60s
+
+frontend tcp-0_0_0_0-443
+    bind *:5551
+    mode tcp
+    use_backend rabbitmq-stream-tls
+    tcp-request inspect-delay 5s
+    tcp-request content accept if { req_ssl_hello_type 1 }
+
+backend rabbitmq-stream-tls
+    mode tcp
+    server rabbit_node0 rabbit_node0:5551 check inter 5000 fall 3
+    server rabbit_node1 rabbit_node1:5551 check inter 5000 fall 3
+    server rabbit_node2 rabbit_node2:5551 check inter 5000 fall 3
+
+listen rabbitmq-stream
+    bind 0.0.0.0:5552
+    balance roundrobin
+    server rabbit_node0 rabbit_node0:5552 check inter 5000 fall 3
+    server rabbit_node1 rabbit_node1:5552 check inter 5000 fall 3
+    server rabbit_node2 rabbit_node2:5552 check inter 5000 fall 3
+
+listen rabbitmq-amqp
+    bind 0.0.0.0:5672
+    balance roundrobin
+    server rabbit_node0 rabbit_node0:5672 check inter 5000 fall 3
+    server rabbit_node1 rabbit_node1:5672 check inter 5000 fall 3
+    server rabbit_node2 rabbit_node2:5672 check inter 5000 fall 3
+
+
+listen rabbitmq-ui
+    bind 0.0.0.0:15672
+    balance roundrobin
+    server rabbit_node0 rabbit_node0:15672 check inter 5000 fall 3
+    server rabbit_node1 rabbit_node1:15672 check inter 5000 fall 3
+    server rabbit_node2 rabbit_node2:15672 check inter 5000 fall 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ line-length = 110
 
 [tool.mypy]
 ignore_missing_imports = true
+exclude = ["venv", ".venv", "compose"]
 
 [[tool.mypy.overrides]]
 module = "local_tests.*"
@@ -43,3 +44,4 @@ ignore_errors = true
 
 [tool.isort]
 profile = "black"
+

--- a/rstream/client.py
+++ b/rstream/client.py
@@ -178,8 +178,12 @@ class BaseClient:
                 count = count + 1
         return count
 
-    async def free_available_id(self, publishing_subscribing_id):
-        self._available_client_ids[publishing_subscribing_id] = True
+    async def free_available_id(self):
+        # loop _available_client_ids to find the first occuped it and free it
+        for _available_client_id in self._available_client_ids:
+            if not _available_client_id:
+                _available_client_id = True
+                return
 
     async def send_publish_frame(self, frame: schema.Publish, version: int = 1) -> None:
         logger.debug("Sending frame: %s", frame)

--- a/rstream/client.py
+++ b/rstream/client.py
@@ -600,7 +600,9 @@ class Client(BaseClient):
             )
         )
 
-    async def declare_publisher(self, stream: str, reference: str, publisher_id: int) -> None:
+    async def declare_publisher(self, stream: str, reference: Optional[str], publisher_id: int) -> None:
+        if reference is None:
+            reference = ""
         await self.sync_request(
             schema.DeclarePublisher(
                 self._corr_id_seq.next(),

--- a/rstream/client.py
+++ b/rstream/client.py
@@ -109,7 +109,6 @@ class BaseClient:
         self._streams: list[str] = []
         # used to assing publish_ids and subscribe_ids
         self._available_client_ids: AtomicInteger = AtomicInteger(0)
-        self._current_id = 0
 
     def start_task(self, name: str, coro: Awaitable[None]) -> None:
         assert name not in self._tasks
@@ -167,7 +166,7 @@ class BaseClient:
         return self._available_client_ids.inc()
 
     async def get_count_available_ids(self):
-        return self._available_client_ids.value
+        return self._max_clients_by_connections - self._available_client_ids.value
 
     async def free_available_id(self):
         self._available_client_ids.dec()

--- a/rstream/consumer.py
+++ b/rstream/consumer.py
@@ -206,10 +206,12 @@ class Consumer:
         logger.debug("_create_subscriber(): Create subscriber")
         #  need to check if the current subscribers for this stream reached the max limit
 
-        client = await self._get_or_create_client(stream)
-        await client.inc_available_id()
         # We can have multiple subscribers sharing same connection, so their ids must be distinct
         subscription_id = await self.get_available_id()
+
+        client = await self._get_or_create_client(stream)
+        await client.inc_available_id()
+
         decoder = decoder or (lambda x: x)
         # the ID is unique per connection
         subscriber = self._subscribers[subscription_id] = _Subscriber(
@@ -320,12 +322,13 @@ class Consumer:
         return subscriber.subscription_id
 
     async def get_available_id(self) -> int:
-        # ok = True
-        # for _client in self._clients.keys():
-        #     ok = ok and  await self._clients[_client].get_count_available_ids()> 0
-        #
-        # if not ok:
-        #     raise exceptions.MaxConsumersPerConnectionReached("Max consumers per connection reached")
+        ok = True
+        for _client in self._clients.keys():
+            v = await self._clients[_client].get_count_available_ids()
+            ok = ok and v > 0
+
+        if not ok:
+            raise exceptions.MaxConsumersPerConnectionReached("Max consumers per connection reached")
 
         for subscribing_id in range(0, self._max_subscribers_by_connection):
             if subscribing_id not in self._subscribers:

--- a/rstream/exceptions.py
+++ b/rstream/exceptions.py
@@ -15,6 +15,10 @@ class ServerError(Exception):
         return cls._registry.get(code, cls)
 
 
+class ClientError(Exception):
+    pass
+
+
 class StreamDoesNotExist(ServerError):
     code = 2
 
@@ -87,9 +91,13 @@ class OffsetNotFound(ServerError):
     code = 19
 
 
-class MaxConsumersPerInstance(ServerError):
-    code = 20
+class MaxConsumersPerInstance(ClientError):
+    pass
 
 
-class MaxPublishersPerInstance(ServerError):
-    code = 21
+class MaxPublishersPerInstance(ClientError):
+    pass
+
+
+class StreamAlreadySubscribed(ClientError):
+    pass

--- a/rstream/exceptions.py
+++ b/rstream/exceptions.py
@@ -87,9 +87,9 @@ class OffsetNotFound(ServerError):
     code = 19
 
 
-class MaxConsumersPerConnectionReached(ServerError):
+class MaxConsumersPerInstance(ServerError):
     code = 20
 
 
-class MaxPublishersPerConnectionReached(ServerError):
+class MaxPublishersPerInstance(ServerError):
     code = 21

--- a/rstream/producer.py
+++ b/rstream/producer.py
@@ -241,7 +241,6 @@ class Producer:
             await client.inc_available_id()
 
             reference = publisher_name
-            # reference = publisher_name or f"{stream}_publisher_{publisher_id}_{str(uuid.uuid4())}"
             publisher = self._publishers[publisher_id] = _Publisher(
                 id=publisher_id,
                 stream=stream,

--- a/rstream/producer.py
+++ b/rstream/producer.py
@@ -184,9 +184,9 @@ class Producer:
                     logger.warning("timeout when closing producer and deleting publisher")
                 except BaseException:
                     logger.exception("exception in delete_publisher in Producer.close")
-            publisher.client.remove_handler(schema.PublishConfirm, publisher.reference)
-            publisher.client.remove_handler(schema.PublishError, publisher.reference)
-            publisher.client.remove_handler(schema.MetadataUpdate, publisher.reference)
+            publisher.client.remove_handler(schema.PublishConfirm, str(publisher.id))
+            publisher.client.remove_handler(schema.PublishError, str(publisher.id))
+            publisher.client.remove_handler(schema.MetadataUpdate, str(publisher.id))
 
         self._publishers.clear()
 
@@ -702,9 +702,9 @@ class Producer:
         if stream in self._publishers:
             publisher = self._publishers[stream]
             await publisher.client.delete_publisher(publisher.id)
-            publisher.client.remove_handler(schema.PublishConfirm, publisher.reference)
-            publisher.client.remove_handler(schema.PublishError, publisher.reference)
-            publisher.client.remove_handler(schema.MetadataUpdate, publisher.reference)
+            publisher.client.remove_handler(schema.PublishConfirm, str(publisher.id))
+            publisher.client.remove_handler(schema.PublishError, str(publisher.id))
+            publisher.client.remove_handler(schema.MetadataUpdate, str(publisher.id))
             del self._publishers[stream]
 
     async def delete_stream(self, stream: str, missing_ok: bool = False) -> None:

--- a/rstream/producer.py
+++ b/rstream/producer.py
@@ -33,7 +33,7 @@ from .compression import (
     CompressionType,
     ICompressionCodec,
 )
-from .constants import Key, SlasMechanism, MAX_ITEM_ALLOWED
+from .constants import Key, SlasMechanism
 from .exceptions import StreamDoesNotExist
 from .utils import OnClosedErrorInfo, RawMessage
 
@@ -84,7 +84,7 @@ class Producer:
         heartbeat: int = 60,
         load_balancer_mode: bool = False,
         max_retries: int = 20,
-        max_publishers_by_connection= MAX_ITEM_ALLOWED,
+        max_publishers_by_connection=256,
         default_batch_publishing_delay: float = 3,
         default_context_switch_value: int = 1000,
         connection_name: str = "",
@@ -106,7 +106,7 @@ class Producer:
         )
         self._default_client: Optional[Client] = None
         self._clients: dict[str, Client] = {}
-        self._publishers: dict[int, _Publisher] = {}
+        self._publishers: dict[str, _Publisher] = {}
         self._waiting_for_confirm: dict[
             str, dict[asyncio.Future[None] | CB[ConfirmationStatus], set[int]]
         ] = defaultdict(dict)
@@ -238,15 +238,13 @@ class Producer:
             client = await self._get_or_create_client(stream)
 
             # We can have multiple publishers sharing same connection, so their ids must be distinct
-            await client.inc_available_id()
+            publisher_id = await client.inc_available_id()
 
-            # reference = publisher_name or f"{stream}_publisher_{publisher_id}_{str(uuid.uuid4())}"
-            publisher_id = await self.get_available_id()
-
-            publisher = self._publishers[publisher_id] = _Publisher(
+            reference = publisher_name or f"{stream}_publisher_{publisher_id}_{str(uuid.uuid4())}"
+            publisher = self._publishers[stream] = _Publisher(
                 id=publisher_id,
                 stream=stream,
-                reference=publisher_name,
+                reference=reference,
                 sequence=utils.MonotonicSeq(),
                 client=client,
             )
@@ -291,22 +289,6 @@ class Producer:
         )
 
         return publisher
-
-    async def get_available_id(self) -> int:
-        # ok = True
-        # for _client in self._clients.keys():
-        #     ok = ok and  await self._clients[_client].get_count_available_ids()> 0
-        #
-        # if not ok:
-        #     raise exceptions.MaxConsumersPerConnectionReached("Max consumers per connection reached")
-
-        for publisher_id in range(0, self._max_publishers_by_connection):
-            if publisher_id not in self._publishers:
-                return publisher_id
-
-        # TODO: Next PR refactor the id count to client pool
-        # remove comment the above code
-        raise exceptions.MaxPublishersPerConnectionReached("Max publishers per connection reached")
 
     async def send_batch(
         self,

--- a/rstream/utils.py
+++ b/rstream/utils.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import itertools
+import threading
 from dataclasses import dataclass
 from typing import Any, Callable, Generator, Optional
 
@@ -69,3 +70,27 @@ class FilterConfiguration:
 
     def match_unfiltered(self) -> bool:
         return self._match_unfiltered
+
+
+class AtomicInteger:
+    def __init__(self, value=0):
+        self._value = int(value)
+        self._lock = threading.Lock()
+
+    def inc(self, d=1):
+        with self._lock:
+            self._value += int(d)
+            return self._value
+
+    def dec(self, d=1):
+        return self.inc(-d)
+
+    @property
+    def value(self):
+        with self._lock:
+            return self._value
+
+    def swap_value(self, v):
+        with self._lock:
+            self._value = int(v)
+            return self._value

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,8 @@ def pytest_addoption(parser):
     parser.addoption("--rmq-cluster-username", action="store", default="guest")
     parser.addoption("--rmq-cluster-password", action="store", default="guest")
     parser.addoption("--rmq-cluster-load-balancer", action="store", type=bool, default=True)
+    # HTTP port for management API in cluster testing
+    parser.addoption("--rmq-cluster-http-port", action="store", type=int, default=15673)
 
 
 @pytest_asyncio.fixture()
@@ -379,3 +381,8 @@ async def cluster_consumer(pytestconfig):
         yield consumer
     finally:
         await consumer.close()
+
+
+@pytest_asyncio.fixture()
+async def http_cluster_port(pytestconfig):
+    return pytestconfig.getoption("rmq_cluster_http_port")

--- a/tests/http_requests.py
+++ b/tests/http_requests.py
@@ -4,8 +4,8 @@ import requests
 from requests.auth import HTTPBasicAuth
 
 
-def get_connections() -> list:
-    request = "http://localhost:15672/api/connections"
+def get_connections(port: int = 15672) -> list:
+    request = "http://localhost:{}/api/connections".format(port)
     response = requests.get(request, auth=HTTPBasicAuth("guest", "guest"))
     response.raise_for_status()
     return response.json()
@@ -24,6 +24,15 @@ def get_connection_present(connection_name: str, connections: list) -> bool:
         if connection["client_properties"]["connection_name"] == connection_name:
             return True
     return False
+
+
+def count_connections_by_name(connection_name: str, port: int = 15672) -> int:
+    count = 0
+    connections = get_connections(port)
+    for connection in connections:
+        if connection["client_properties"].get("connection_name") == connection_name:
+            count += 1
+    return count
 
 
 def delete_connection(name: str) -> int:

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -249,12 +249,14 @@ async def test_consumer_resubscribe_when_not_consumed_events_in_queue(
         await producer.close()
 
 
-async def test_offset_type_timestamp(stream: str, consumer: Consumer, producer: Producer) -> None:
+async def test_offset_type_timestamp(consumer: Consumer, producer: Producer) -> None:
+    stream = "test_offset_type_timestamp_{}".format(time.time())
+    await producer.create_stream(stream=stream)
     messages = [str(i).encode() for i in range(1, 5_000)]
     await producer.send_batch(stream, messages)
 
     # mark time in between message batches
-    await asyncio.sleep(1)
+    await asyncio.sleep(1.5)
     now = int(time.time() * 1000)
 
     messages = [str(i).encode() for i in range(5_000, 5_100)]
@@ -267,7 +269,9 @@ async def test_offset_type_timestamp(stream: str, consumer: Consumer, producer: 
         callback=lambda message, message_context: captured.append(bytes(message)),
         offset_specification=ConsumerOffsetSpecification(offset_type=OffsetType.TIMESTAMP, offset=now),
     )
+    await asyncio.sleep(1)
     await wait_for(lambda: len(captured) > 0 and captured[0] >= b"5000", 5)
+    await producer.delete_stream(stream)
 
 
 async def test_offset_type_next(stream: str, consumer: Consumer, producer: Producer) -> None:

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -288,14 +288,14 @@ async def test_offset_type_next(stream: str, consumer: Consumer, producer: Produ
 
 async def test_consume_with_resubscribe(stream: str, consumer: Consumer, producer: Producer) -> None:
     captured_by_first_consumer: list[bytes] = []
-    subscriber_name = await consumer.subscribe(
+    subscriber_id = await consumer.subscribe(
         stream, callback=lambda message, message_context: captured_by_first_consumer.append(bytes(message))
     )
     await producer.send_wait(stream, b"one")
     await wait_for(lambda: len(captured_by_first_consumer) >= 1)
     assert captured_by_first_consumer == [b"one"]
 
-    await consumer.unsubscribe(subscriber_name)
+    await consumer.unsubscribe(subscriber_id)
 
     captured_by_second_consumer: list[bytes] = []
     await consumer.subscribe(

--- a/tests/test_producer.py
+++ b/tests/test_producer.py
@@ -234,8 +234,9 @@ async def test_publish_deduplication(stream: str, producer: Producer, consumer: 
     async def publish_with_ids(*ids):
         for publishing_id in ids:
             await producer.send_wait(
-                stream,
-                RawMessage(f"test_{publishing_id}".encode(), publishing_id),
+                stream=stream,
+                message=RawMessage(f"test_{publishing_id}".encode(), publishing_id=publishing_id),
+                publisher_name="MyProducerName",
             )
 
     await publish_with_ids(1, 2, 3)
@@ -259,8 +260,7 @@ async def test_publish_deduplication_async(stream: str, producer: Producer, cons
     async def publish_with_ids(*ids):
         for publishing_id in ids:
             await producer.send(
-                stream,
-                RawMessage(f"test_{publishing_id}".encode(), publishing_id),
+                stream, RawMessage(f"test_{publishing_id}".encode(), publishing_id), "MyProducerName"
             )
 
     await publish_with_ids(1, 2, 3)


### PR DESCRIPTION
Refactors the producer implementation to use publisher IDs as map keys instead of reference strings, improving performance and consistency in publisher management.

- Replaces string references with integer IDs as the primary key for tracking publishers
- Updates handler registration to use publisher IDs instead of references
- Modifies publisher creation logic to handle optional references

Breaking changes
- It is not possible to subscribe the same stream twice to the same consumer instance anymore


