### PR TITLE
fix: evict closed clients from ClientPool on get()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Fixed
+- `ClientPool.get()` now evicts clients whose connection is no longer alive before
+  scanning or creating one. Short-lived locator connections (e.g. the per-call
+  `stream_exists()`/metadata probes and recovery checks) are closed after use but
+  were never removed from the pool, so each call leaked one `Client` (~1 KB) and
+  memory grew linearly with the number of locator calls for the lifetime of the
+  producer.
+
 ## [[1.0.1](https://github.com/rabbitmq-community/rstream/releases/tag/v1.0.1)]
 
 This release fixes source-distribution installs, adds release automation, and documents agent guidance for contributors.

--- a/rstream/client.py
+++ b/rstream/client.py
@@ -753,6 +753,18 @@ class ClientPool:
         sasl_configuration_mechanism = sasl_configuration_mechanism or self._sasl_configuration_mechanism
         is_locator_request = locator_request
 
+        # Evict clients that are no longer connected. Short-lived clients (e.g. the
+        # locator connections opened by stream_exists()/metadata queries and closed
+        # right after use) would otherwise accumulate in _clients forever: nothing
+        # removes a closed client until ClientPool.close(), so every such call leaks
+        # one Client for the lifetime of the pool.
+        if desired_addr in self._clients:
+            self._clients[desired_addr] = [
+                client for client in self._clients[desired_addr] if client.is_connection_alive()
+            ]
+            if not self._clients[desired_addr]:
+                del self._clients[desired_addr]
+
         # check if at least one client of desired_addr is connected
         if desired_addr in self._clients:
             for client in self._clients[desired_addr]:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,9 +1,9 @@
-from unittest.mock import ANY
+from unittest.mock import ANY, AsyncMock
 
 import pytest
 
 from rstream import schema
-from rstream.client import Client
+from rstream.client import Client, ClientPool
 from rstream.constants import Key
 
 pytestmark = pytest.mark.asyncio
@@ -103,3 +103,124 @@ async def exchange_command_versions(client: Client) -> None:
     assert command_version_server.key_command == Key.Publish.value
     assert command_version_server.min_version == expected_min_version
     assert command_version_server.max_version == expected_max_version
+
+
+class _FakeClient:
+    """Stand-in for a real Client that ClientPool.get() can manage without a broker."""
+
+    def __init__(self, alive: bool = True) -> None:
+        self._alive = alive
+        self.is_started = True
+
+    def is_connection_alive(self) -> bool:
+        return self._alive
+
+    async def get_count_available_ids(self) -> int:
+        return 1
+
+    @property
+    def is_locator(self) -> bool:
+        return False
+
+    def add_stream(self, stream: str) -> None:
+        pass
+
+
+def _make_client_pool() -> ClientPool:
+    return ClientPool(
+        host="localhost",
+        port=5552,
+        vhost="/",
+        username="guest",
+        password="guest",
+        frame_max=1024 * 1024,
+        heartbeat=60,
+        load_balancer_mode=False,
+        max_retries=3,
+    )
+
+
+async def test_client_pool_evicts_closed_clients_on_get() -> None:
+    """A closed client left in the pool (e.g. a locator connection closed after a
+    stream_exists() query) is evicted before a new client is created."""
+    pool = _make_client_pool()
+    addr = pool.addr
+    pool._clients[addr].append(_FakeClient(alive=False))
+
+    async def fake_new(**kwargs: object) -> _FakeClient:
+        return _FakeClient(alive=True)
+
+    pool.new = AsyncMock(side_effect=fake_new)  # type: ignore[method-assign]
+
+    for _ in range(5):
+        await pool.get(connection_name=None)
+
+    clients = pool._clients[addr]
+    assert len(clients) == 1
+    assert clients[0].is_connection_alive() is True
+    # only the first get() needed to create a client; the rest reused it
+    assert pool.new.await_count == 1
+
+
+async def test_client_pool_reuses_alive_client() -> None:
+    """An alive client is reused instead of appending a new one."""
+    pool = _make_client_pool()
+    addr = pool.addr
+    live = _FakeClient(alive=True)
+    pool._clients[addr].append(live)
+
+    pool.new = AsyncMock(  # type: ignore[method-assign]
+        side_effect=AssertionError("new() must not be called when a client can be reused")
+    )
+
+    for _ in range(3):
+        got = await pool.get(connection_name=None)
+        assert got is live
+
+    assert len(pool._clients[addr]) == 1
+    pool.new.assert_not_awaited()
+
+
+async def test_client_pool_evicts_only_closed_clients() -> None:
+    """Dead clients are dropped but live ones are still reused."""
+    pool = _make_client_pool()
+    addr = pool.addr
+    live = _FakeClient(alive=True)
+    pool._clients[addr] = [_FakeClient(alive=False), live]
+
+    pool.new = AsyncMock(  # type: ignore[method-assign]
+        side_effect=AssertionError("new() must not be called when a client can be reused")
+    )
+
+    got = await pool.get(connection_name=None)
+
+    assert got is live
+    assert pool._clients[addr] == [live]
+
+
+async def test_client_pool_does_not_grow_across_open_close_cycles() -> None:
+    """Reproduces the Producer.stream_exists() pattern: every call opens a short-lived
+    locator client and closes it right after. The pool must not accumulate one dead
+    Client per call."""
+    pool = _make_client_pool()
+    addr = pool.addr
+    created: list[_FakeClient] = []
+
+    async def fake_new(**kwargs: object) -> _FakeClient:
+        client = _FakeClient(alive=True)
+        created.append(client)
+        return client
+
+    pool.new = AsyncMock(side_effect=fake_new)  # type: ignore[method-assign]
+
+    for _ in range(100):
+        client = await pool.get(connection_name=None)
+        # emulate _close_locator_connection(): a locator holds no streams and is
+        # closed right after the metadata query
+        client._alive = False
+
+    # a fresh connection is opened on every cycle...
+    assert len(created) == 100
+    # ...but the closed clients are evicted instead of being retained forever
+    assert len(pool._clients[addr]) == 1
+    assert pool._clients[addr][0] is created[-1]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,3 +1,4 @@
+from typing import cast
 from unittest.mock import ANY, AsyncMock
 
 import pytest
@@ -140,12 +141,18 @@ def _make_client_pool() -> ClientPool:
     )
 
 
+def _as_client(client: _FakeClient) -> Client:
+    """Type helper: _FakeClient only implements the subset of Client that
+    ClientPool.get() touches, so seed it into the pool as a Client."""
+    return cast(Client, client)
+
+
 async def test_client_pool_evicts_closed_clients_on_get() -> None:
     """A closed client left in the pool (e.g. a locator connection closed after a
     stream_exists() query) is evicted before a new client is created."""
     pool = _make_client_pool()
     addr = pool.addr
-    pool._clients[addr].append(_FakeClient(alive=False))
+    pool._clients[addr].append(_as_client(_FakeClient(alive=False)))
 
     async def fake_new(**kwargs: object) -> _FakeClient:
         return _FakeClient(alive=True)
@@ -166,7 +173,7 @@ async def test_client_pool_reuses_alive_client() -> None:
     """An alive client is reused instead of appending a new one."""
     pool = _make_client_pool()
     addr = pool.addr
-    live = _FakeClient(alive=True)
+    live = _as_client(_FakeClient(alive=True))
     pool._clients[addr].append(live)
 
     pool.new = AsyncMock(  # type: ignore[method-assign]
@@ -185,8 +192,8 @@ async def test_client_pool_evicts_only_closed_clients() -> None:
     """Dead clients are dropped but live ones are still reused."""
     pool = _make_client_pool()
     addr = pool.addr
-    live = _FakeClient(alive=True)
-    pool._clients[addr] = [_FakeClient(alive=False), live]
+    live = _as_client(_FakeClient(alive=True))
+    pool._clients[addr] = [_as_client(_FakeClient(alive=False)), live]
 
     pool.new = AsyncMock(  # type: ignore[method-assign]
         side_effect=AssertionError("new() must not be called when a client can be reused")
@@ -214,10 +221,11 @@ async def test_client_pool_does_not_grow_across_open_close_cycles() -> None:
     pool.new = AsyncMock(side_effect=fake_new)  # type: ignore[method-assign]
 
     for _ in range(100):
-        client = await pool.get(connection_name=None)
+        await pool.get(connection_name=None)
         # emulate _close_locator_connection(): a locator holds no streams and is
-        # closed right after the metadata query
-        client._alive = False
+        # closed right after the metadata query. Each get() creates a fresh client
+        # because the previous one was marked dead here and evicted on the next call.
+        created[-1]._alive = False
 
     # a fresh connection is opened on every cycle...
     assert len(created) == 100

--- a/tests/test_producer.py
+++ b/tests/test_producer.py
@@ -91,6 +91,21 @@ async def test_delete_super_stream_doesnt_exist(super_stream_producer: SuperStre
         pytest.fail("Unexpected error")
 
 
+async def test_stream_exists_does_not_accumulate_locator_clients(producer: Producer) -> None:
+    """Regression: Producer.stream_exists() opens and immediately closes a short-lived
+    locator connection on every call. Those closed clients must be evicted from
+    ClientPool instead of accumulating (one leaked Client per call) for the lifetime
+    of the producer."""
+    stream_name = "test-stream-locator-pool-{}".format(time.time())
+    for _ in range(10):
+        # a stream that does not exist makes stream_exists() return False, so the
+        # producer never sends and no partition/long-lived client is created
+        assert await producer.stream_exists(stream_name) is False
+
+    total_clients = sum(len(clients) for clients in producer._pool._clients.values())
+    assert total_clients == 1
+
+
 async def test_publishing_sequence(stream: str, producer: Producer, consumer: Consumer) -> None:
     captured: list[bytes] = []
     await consumer.subscribe(


### PR DESCRIPTION
## Summary

`ClientPool` keeps every `Client` it has ever created in `_clients` and only clears them in `close()`. `get()` appends a new client whenever no live reusable one exists, but nothing ever removes closed clients — so any workload that opens short-lived clients leaks one `Client` (~1 KB) per call for the lifetime of the producer:

- `Producer.stream_exists()` / `SuperStreamProducer.stream_exists()` open a locator connection via `default_client` and then `_close_locator_connection()` closes it (0 streams) and nulls `_default_client`, so every call opens and appends a new, soon-dead `Client`.
- The recovery loop (`BackOffRecoveryStrategy.recover`) calls `entity.stream_exists()` on the same path.
- In clustered deployments the pool address differs from partition leader addresses, so `get()` can't reuse the long-lived partition clients either.

Observed in the field: `/healthz` polling `stream_exists()` ~46k/day/pod grew RSS ~1.3 KB per probe (tens of MB/day) until pod OOM, with a healthy broker and no involvement of the publish path. Each call also pays a full TCP handshake (~200 ms) because the locator is never reused.

## Fix

In `ClientPool.get()`, evict clients whose `is_connection_alive()` is `False` before scanning/reusing or creating a client, and drop the `_clients` key when the list becomes empty. This restores the pool invariant (only reusable live connections are retained) and covers every short-lived locator usage, not just this one call site:

```python
if desired_addr in self._clients:
    self._clients[desired_addr] = [
        client for client in self._clients[desired_addr] if client.is_connection_alive()
    ]
    if not self._clients[desired_addr]:
        del self._clients[desired_addr]
```

## Tests

- Brokerless unit tests in `tests/test_client.py` driving `ClientPool.get()` with a fake/closed client: dead clients are evicted before a new one is created; alive clients are still reused without appending; repeated open/close cycles (the `stream_exists()` pattern) keep the pool bounded. Three of these fail against the unpatched code.
- Integration regression in `tests/test_producer.py`: a fresh `Producer` calling `stream_exists()` on a nonexistent stream (no sends) N times must not grow `producer._pool._clients`.

## Verification

- `tests/test_producer.py`, `tests/test_client.py`, `tests/test_consumer.py` pass against a live RabbitMQ (3.13 + `rabbitmq_stream`).
- Soak against the live broker: before the fix `pool_clients` grew 1 → 10 across 10 `stream_exists()` probes; after the fix it stays at 1 across 200 probes with flat RSS.
- `black --check` and `flake8` clean on changed files.

## Changelog

`CHANGELOG.md` updated under `Unreleased → Fixed`.
