### PR TITLE
fix(producer): split buffered batches that exceed the negotiated fram…

### DIFF
--- a/rstream/client.py
+++ b/rstream/client.py
@@ -154,6 +154,10 @@ class BaseClient:
     def is_connection_alive(self) -> bool:
         return self._is_not_closed
 
+    @property
+    def frame_max(self) -> int:
+        return self._frame_max
+
     def add_stream(self, stream: str):
         self._streams.append(stream)
 

--- a/rstream/producer.py
+++ b/rstream/producer.py
@@ -78,6 +78,20 @@ class ConfirmationStatus:
 
 logger = logging.getLogger(__name__)
 
+# Wire-format overhead (in bytes) added by a Publish frame around a batch of
+# messages: frame header (4 bytes length + 2 bytes key + 2 bytes version) +
+# publisher_id (1 byte) + messages count (4 bytes). See encode_publish().
+_PUBLISH_FRAME_OVERHEAD = 13
+# Per-message overhead: publishing_id (8 bytes) + data length prefix (4 bytes).
+_MESSAGE_OVERHEAD = 12
+
+
+def _message_frame_size(message: schema.Message) -> int:
+    size = _MESSAGE_OVERHEAD + len(message.data)
+    if message.filter_value is not None:
+        size += 2 + len(message.filter_value.encode("utf-8"))
+    return size
+
 
 class Producer(IReliableEntity):
     def __init__(
@@ -446,9 +460,35 @@ class Producer(IReliableEntity):
         if self._close_called:
             return []
 
-        messages = []
+        messages: list[schema.Message] = []
+        current_frame_size = _PUBLISH_FRAME_OVERHEAD
         publishing_ids = set()
         publishing_ids_callback: dict[CB[ConfirmationStatus], set[int]] = defaultdict(set)
+
+        async def _flush(publisher: _Publisher) -> None:
+            nonlocal current_frame_size
+            if len(messages) == 0:
+                return
+            if self._filter_value_extractor is None:
+                logger.debug("_send_batch_async: Not a Filtering case send_publish_frame v1")
+                await publisher.client.send_publish_frame(
+                    schema.Publish(
+                        publisher_id=publisher.id,
+                        messages=list(messages),
+                    ),
+                )
+            else:
+                logger.debug("_send_batch_async: Filtering case send_publish_frame v2")
+                await publisher.client.send_publish_frame(
+                    schema.Publish(
+                        publisher_id=publisher.id,
+                        messages=list(messages),
+                    ),
+                    version=2,
+                )
+            publishing_ids.update([m.publishing_id for m in messages])
+            messages.clear()
+            current_frame_size = _PUBLISH_FRAME_OVERHEAD
 
         for item in batch:
             async with self._lock:
@@ -468,23 +508,33 @@ class Producer(IReliableEntity):
                     msg.publishing_id = publisher.sequence.next()
                 if self._filter_value_extractor is None:
                     logger.debug("_send_batch_async: Filtering not active ingesting messages list")
-                    messages.append(
-                        schema.Message(
-                            publishing_id=msg.publishing_id,
-                            filter_value=None,
-                            data=bytes(msg),
-                        )
+                    new_message = schema.Message(
+                        publishing_id=msg.publishing_id,
+                        filter_value=None,
+                        data=bytes(msg),
                     )
                 else:
                     logger.debug("_send_batch_async: Filtering active ingesting messages list")
                     value_filter: str = await self._filter_value_extractor(msg)
-                    messages.append(
-                        schema.Message(
-                            publishing_id=msg.publishing_id,
-                            filter_value=value_filter,
-                            data=bytes(msg),
-                        )
+                    new_message = schema.Message(
+                        publishing_id=msg.publishing_id,
+                        filter_value=value_filter,
+                        data=bytes(msg),
                     )
+
+                # Respect the connection's negotiated frame_max: flush the
+                # currently buffered messages before they would push the next
+                # Publish frame past the broker's limit.
+                message_size = _message_frame_size(new_message)
+                if messages and current_frame_size + message_size > publisher.client.frame_max:
+                    logger.debug(
+                        "_send_batch_async: frame_max reached, flushing %d buffered messages",
+                        len(messages),
+                    )
+                    await _flush(publisher)
+
+                messages.append(new_message)
+                current_frame_size += message_size
 
                 if item.callback is not None:
                     publishing_ids_callback[item.callback].add(msg.publishing_id)
@@ -492,27 +542,7 @@ class Producer(IReliableEntity):
             else:
                 logger.debug("_send_batch_async: Compression case")
                 compression_codec = item.entry
-                if len(messages) > 0:
-                    if self._filter_value_extractor is None:
-                        logger.debug("_send_batch_async: Not a filtering case publishing frame")
-                        await publisher.client.send_publish_frame(
-                            schema.Publish(
-                                publisher_id=publisher.id,
-                                messages=messages,
-                            ),
-                        )
-                    else:
-                        logger.debug("_send_batch_async: Filtering case ingesting messages list")
-                        value_filter = await self._filter_value_extractor(msg)
-                        messages.append(
-                            schema.Message(
-                                publishing_id=msg.publishing_id,  # type: ignore[arg-type]
-                                filter_value=value_filter,
-                                data=bytes(msg),
-                            )
-                        )
-                    # publishing_ids.update([m.publishing_id for m in messages])
-                    messages.clear()
+                await _flush(publisher)
                 for _ in range(item.entry.messages_count()):
                     publishing_id = publisher.sequence.next()
 
@@ -534,25 +564,7 @@ class Producer(IReliableEntity):
                 if item.callback is not None:
                     publishing_ids_callback[item.callback].add(publishing_id)
 
-        if len(messages) > 0:
-            if self._filter_value_extractor is None:
-                logger.debug("_send_batch_async: Not a Filtering case send_publish_frame v1")
-                await publisher.client.send_publish_frame(
-                    schema.Publish(
-                        publisher_id=publisher.id,
-                        messages=messages,
-                    ),
-                )
-            else:
-                logger.debug("_send_batch_async: Filtering case send_publish_frame v2")
-                await publisher.client.send_publish_frame(
-                    schema.Publish(
-                        publisher_id=publisher.id,
-                        messages=messages,
-                    ),
-                    version=2,
-                )
-            publishing_ids.update([m.publishing_id for m in messages])
+        await _flush(publisher)
 
         for callback in publishing_ids_callback:
             if callback not in self._waiting_for_confirm[publisher.id]:

--- a/tests/test_producer.py
+++ b/tests/test_producer.py
@@ -21,6 +21,8 @@ from rstream import (
     amqp_decoder,
     exceptions,
 )
+from rstream.client import Client
+from rstream.encoding import encode_publish
 
 from .util import (
     http_api_delete_connection_and_check,
@@ -225,6 +227,71 @@ async def test_publishing_sequence_async(stream: str, producer: Producer, consum
 
     await wait_for(lambda: len(captured) == 3)
     assert captured == [b"one", b"two", b"three"]
+
+
+async def test_send_splits_batch_exceeding_frame_max(stream: str, consumer: Consumer) -> None:
+    # With a small frame_max, a buffered batch whose messages would together
+    # exceed it must be split into several Publish frames instead of being
+    # sent (and rejected/dropped by the broker) as a single oversized frame.
+    frame_max = 5000
+    message_size = 1000
+    num_messages = 40
+    payload = b"x" * message_size
+
+    captured: list[bytes] = []
+    await consumer.subscribe(
+        stream, callback=lambda message, message_context: captured.append(bytes(message))
+    )
+
+    producer = Producer("localhost", username="guest", password="guest", frame_max=frame_max)
+    await producer.start()
+    try:
+        for _ in range(num_messages):
+            await producer.send(stream, payload)
+
+        await wait_for(lambda: len(captured) == num_messages, 5, 0.5)
+    finally:
+        await producer.close()
+
+    assert captured == [payload] * num_messages
+
+
+async def test_send_batch_async_frames_never_exceed_frame_max(
+    stream: str, consumer: Consumer, monkeypatch
+) -> None:
+    frame_max = 5000
+    message_size = 1000
+    num_messages = 40
+    payload = b"x" * message_size
+
+    captured: list[bytes] = []
+    await consumer.subscribe(
+        stream, callback=lambda message, message_context: captured.append(bytes(message))
+    )
+
+    sent_frame_sizes: list[int] = []
+    original_send_publish_frame = Client.send_publish_frame
+
+    async def spy_send_publish_frame(self, frame, version=1):
+        # Measure the exact bytes that will be written on the wire for this
+        # frame, the same way Connection.write_frame_publish() does.
+        sent_frame_sizes.append(len(encode_publish(frame, version)))
+        await original_send_publish_frame(self, frame, version)
+
+    monkeypatch.setattr(Client, "send_publish_frame", spy_send_publish_frame)
+
+    producer = Producer("localhost", username="guest", password="guest", frame_max=frame_max)
+    await producer.start()
+    try:
+        for _ in range(num_messages):
+            await producer.send(stream, payload)
+
+        await wait_for(lambda: len(captured) == num_messages, 5, 0.5)
+    finally:
+        await producer.close()
+
+    assert len(sent_frame_sizes) > 1, "expected the batch to be split across multiple frames"
+    assert all(size <= frame_max for size in sent_frame_sizes)
 
 
 async def test_publish_deduplication(stream: str, producer: Producer, consumer: Consumer) -> None:


### PR DESCRIPTION
…e_max

  _publish_buffered_messages / _send_batch_async built a single Publish
  frame from an entire buffered batch, ignoring the connection's
  negotiated frame_max. Once the encoded frame exceeded the broker's
  limit, the broker closed the connection with "frame too large",
  silently losing the buffered messages.

  Track the accumulated wire size of the messages being batched and
  flush a Publish frame via send_publish_frame before the next message
  would push it past frame_max, mirroring the fix in
  rabbitmq-stream-dotnet-client PR #473. Expose Client.frame_max so the
  producer can read the value actually negotiated with the broker.
  Also fixes a latent bug where publishing_ids weren't recorded when
  flushing pending messages ahead of a compressed sub-batch.

  Add regression tests that reproduce the "frame too large" disconnect
  with a small frame_max and verify frames stay within the limit.

Fixes: https://github.com/rabbitmq-community/rstream/issues/274