### PR TITLE
fix(producer): stop reconnection races from silently dropping publish…

### DIFF
--- a/docs/examples/reliable_client/BestPracticesClient.py
+++ b/docs/examples/reliable_client/BestPracticesClient.py
@@ -47,11 +47,11 @@ async def print_test_variables():
         await asyncio.sleep(5)
         # the number of confirmed messages should be the same as the total messages we sent
         logging.info(
-            "[Messages confirmed: {}, Messages Error:{}] Total: {}".format(
+            "[Messages confirmed: {:,}, Messages Error: {:,}] Total: {:,}".format(
                 confirmed_count, error_count, confirmed_count + error_count
             )
         )
-        logging.info("[Messages consumed: {}]".format(messages_consumed))
+        logging.info("[Messages consumed: {:,}]".format(messages_consumed))
 
 
 # Routing instruction for SuperStream Producer
@@ -160,11 +160,13 @@ async def make_consumer(rabbitmq_data: dict) -> Consumer | SuperStreamConsumer: 
 # Where the confirmation happens
 async def _on_publish_confirm_client(confirmation: ConfirmationStatus) -> None:
     global confirmed_count
+    global error_count
     if confirmation.is_confirmed:
         confirmed_count = confirmed_count + 1
     else:
+        error_count = error_count + 1
         print(
-            "message id: {} not confirmed. Response code {}".format(
+            "message id: {:,} not confirmed. Response code {}".format(
                 confirmation.message_id, confirmation.response_code
             )
         )
@@ -243,12 +245,17 @@ async def publish(rabbitmq_configuration: dict):
                 )
                 error_count = error_count + 1
                 await asyncio.sleep(2)
-
     # await producer.close()  # type: ignore
 
     end_time = time.perf_counter()
+    elapsed = end_time - start_time
+    total_sent = messages_per_producer * producers
+    rate = total_sent / elapsed if elapsed > 0 else 0
     print(
-        f"Sent {messages_per_producer} messages for each of the {producers} producers in {end_time - start_time:0.4f} seconds"
+        "Sent {:,} messages for each of the {:,} producers ({:,} messages total) "
+        "in {:0.4f} seconds ({:,.0f} msg/s)".format(
+            messages_per_producer, producers, total_sent, elapsed, rate
+        )
     )
 
 

--- a/docs/examples/reliable_client/appsettings.json
+++ b/docs/examples/reliable_client/appsettings.json
@@ -12,7 +12,7 @@
     "Producers": 5,
     "Consumers": 5,
     "DelayDuringSendMs":0,
-    "MessagesToSend": 100000000,
+    "MessagesToSend": 5000000,
     "StreamName": "super_cluster_stream",
     "PartitionsCount": 5,
     "Logging": "info"

--- a/rstream/producer.py
+++ b/rstream/producer.py
@@ -78,6 +78,12 @@ class ConfirmationStatus:
 
 logger = logging.getLogger(__name__)
 
+# Sentinel response_code used for ConfirmationStatus objects raised locally
+# when a connection is lost before the broker's PublishConfirm/PublishError
+# frame arrives. Real broker response codes are non-negative, so -1 can't be
+# confused with one.
+_CONNECTION_LOST_RESPONSE_CODE = -1
+
 # Wire-format overhead (in bytes) added by a Publish frame around a batch of
 # messages: frame header (4 bytes length + 2 bytes key + 2 bytes version) +
 # publisher_id (1 byte) + messages count (4 bytes). See encode_publish().
@@ -407,6 +413,28 @@ class Producer(IReliableEntity):
                     )
                 )
 
+        publishing_ids.update([m.publishing_id for m in messages])
+
+        # Register confirmation tracking before the frame is sent: on a fast,
+        # stable connection the broker's PublishConfirm can arrive before this
+        # coroutine is scheduled again, so registering after
+        # send_publish_frame would race with _on_publish_confirm and silently
+        # drop the confirmation for these publishing_ids.
+        future: Optional[asyncio.Future[None]] = None
+        if not sync:
+            logger.debug("_send_batch: Not sync case")
+            if callback is not None:
+                if callback not in self._waiting_for_confirm[publisher.id]:
+                    self._waiting_for_confirm[publisher.id][callback] = set()
+
+                self._waiting_for_confirm[publisher.id][callback].update(publishing_ids)
+
+        # this is just called in case of send_wait
+        else:
+            logger.debug("[producer] Send batch in synchronous mode, waiting for confirms")
+            future = asyncio.Future()
+            self._waiting_for_confirm[publisher.id][future] = publishing_ids.copy()
+
         if len(messages) > 0:
             if self._filter_value_extractor is None:
                 logger.debug("_send_batch: Calling send_publish_frame version 1")
@@ -427,21 +455,8 @@ class Producer(IReliableEntity):
                     version=2,
                 )
 
-            publishing_ids.update([m.publishing_id for m in messages])
-
-        if not sync:
-            logger.debug("_send_batch: Not sync case")
-            if callback is not None:
-                if callback not in self._waiting_for_confirm[publisher.id]:
-                    self._waiting_for_confirm[publisher.id][callback] = set()
-
-                self._waiting_for_confirm[publisher.id][callback].update(publishing_ids)
-
-        # this is just called in case of send_wait
-        else:
-            logger.debug("[producer] Send batch in synchronous mode, waiting for confirms")
-            future: asyncio.Future[None] = asyncio.Future()
-            self._waiting_for_confirm[publisher.id][future] = publishing_ids.copy()
+        if sync:
+            assert future is not None
             await asyncio.wait_for(future, timeout)
 
         return list(publishing_ids)
@@ -463,12 +478,27 @@ class Producer(IReliableEntity):
         messages: list[schema.Message] = []
         current_frame_size = _PUBLISH_FRAME_OVERHEAD
         publishing_ids = set()
-        publishing_ids_callback: dict[CB[ConfirmationStatus], set[int]] = defaultdict(set)
+        # ids of messages currently buffered in `messages` (not yet flushed),
+        # grouped by the callback to notify once they're confirmed.
+        pending_confirmations: dict[CB[ConfirmationStatus], set[int]] = defaultdict(set)
+
+        def _register_pending_confirmations(publisher: _Publisher) -> None:
+            # Register confirmation tracking before the frame is actually
+            # sent: on a fast/stable connection the broker's PublishConfirm
+            # can arrive before this coroutine is scheduled again, so
+            # registering after send_publish_frame/send_frame would race
+            # with _on_publish_confirm and silently drop the confirmation.
+            for cb, ids in pending_confirmations.items():
+                if cb not in self._waiting_for_confirm[publisher.id]:
+                    self._waiting_for_confirm[publisher.id][cb] = set()
+                self._waiting_for_confirm[publisher.id][cb].update(ids)
+            pending_confirmations.clear()
 
         async def _flush(publisher: _Publisher) -> None:
             nonlocal current_frame_size
             if len(messages) == 0:
                 return
+            _register_pending_confirmations(publisher)
             if self._filter_value_extractor is None:
                 logger.debug("_send_batch_async: Not a Filtering case send_publish_frame v1")
                 await publisher.client.send_publish_frame(
@@ -537,7 +567,7 @@ class Producer(IReliableEntity):
                 current_frame_size += message_size
 
                 if item.callback is not None:
-                    publishing_ids_callback[item.callback].add(msg.publishing_id)
+                    pending_confirmations[item.callback].add(msg.publishing_id)
 
             else:
                 logger.debug("_send_batch_async: Compression case")
@@ -545,6 +575,10 @@ class Producer(IReliableEntity):
                 await _flush(publisher)
                 for _ in range(item.entry.messages_count()):
                     publishing_id = publisher.sequence.next()
+
+                if item.callback is not None:
+                    pending_confirmations[item.callback].add(publishing_id)
+                _register_pending_confirmations(publisher)
 
                 logger.debug("_send_batch_async: PublishSubBatching")
                 await publisher.client.send_frame(
@@ -561,16 +595,7 @@ class Producer(IReliableEntity):
                 )
                 publishing_ids.update([publishing_id])
 
-                if item.callback is not None:
-                    publishing_ids_callback[item.callback].add(publishing_id)
-
         await _flush(publisher)
-
-        for callback in publishing_ids_callback:
-            if callback not in self._waiting_for_confirm[publisher.id]:
-                self._waiting_for_confirm[publisher.id][callback] = set()
-
-            self._waiting_for_confirm[publisher.id][callback].update(publishing_ids_callback[callback])
 
         return list(publishing_ids)
 
@@ -745,7 +770,7 @@ class Producer(IReliableEntity):
             if result is not None and inspect.isawaitable(result):
                 await result
 
-        await self.maybe_restart_producer("Metadata Update", frame.metadata_info.stream)
+        asyncio.create_task(self.maybe_restart_producer("Metadata Update", frame.metadata_info.stream))
 
     async def create_stream(
         self,
@@ -896,10 +921,31 @@ class Producer(IReliableEntity):
 
         for stream in disconnection_info.streams.copy():
             reason = disconnection_info.reason
-            await self.maybe_restart_producer(reason, stream)
+            asyncio.create_task(self.maybe_restart_producer(reason, stream))
 
     async def clean_list(self, stream: str) -> None:
         pass
+
+    async def _fail_pending_confirmations(self, publisher_id: int, reason: str) -> None:
+        # Messages already written on the wire but not yet confirmed when the
+        # connection drops would otherwise be lost silently: the publisher_id
+        # is gone, so no PublishConfirm/PublishError frame for it will ever
+        # arrive, and on_publish_confirm would simply never be called for them.
+        waiting = self._waiting_for_confirm.pop(publisher_id, None)
+        if not waiting:
+            return
+
+        for confirmation, ids in waiting.items():
+            if isinstance(confirmation, asyncio.Future):
+                if not confirmation.cancelled():
+                    confirmation.set_exception(exceptions.ServerError(reason))
+                continue
+
+            for message_id in ids:
+                confirmation_status = ConfirmationStatus(message_id, False, _CONNECTION_LOST_RESPONSE_CODE)
+                result = confirmation(confirmation_status)
+                if result is not None and inspect.isawaitable(result):
+                    await result
 
     async def maybe_restart_producer(self, reason: str, stream: str):
         async with self._lock:
@@ -909,6 +955,7 @@ class Producer(IReliableEntity):
             await self._remove_stream_from_client(stream)
 
         if pub is not None:
+            await self._fail_pending_confirmations(pub.id, reason)
             result = self._recovery_strategy.recover(
                 self,
                 stream=stream,

--- a/rstream/recovery.py
+++ b/rstream/recovery.py
@@ -23,7 +23,7 @@ class IReliableEntity(ABC):
         pass
 
     def __init__(self):
-        self._recovery_strategy: RecoveryStrategy
+        self._recovery_strategy: RecoveryStrategy  # type: ignore
 
 
 class RecoveryStrategy(ABC):

--- a/tests/test_producer.py
+++ b/tests/test_producer.py
@@ -689,7 +689,7 @@ def _fake_publisher(stream: str, send_publish_frame) -> _Publisher:
         reference=None,
         stream=stream,
         sequence=utils.MonotonicSeq(),
-        client=SimpleNamespace(frame_max=1024 * 1024, send_publish_frame=send_publish_frame),  #type:ignore
+        client=SimpleNamespace(frame_max=1024 * 1024, send_publish_frame=send_publish_frame),  # type:ignore
     )
 
 

--- a/tests/test_producer.py
+++ b/tests/test_producer.py
@@ -689,7 +689,7 @@ def _fake_publisher(stream: str, send_publish_frame) -> _Publisher:
         reference=None,
         stream=stream,
         sequence=utils.MonotonicSeq(),
-        client=SimpleNamespace(frame_max=1024 * 1024, send_publish_frame=send_publish_frame),
+        client=SimpleNamespace(frame_max=1024 * 1024, send_publish_frame=send_publish_frame),  # type: ignore
     )
 
 

--- a/tests/test_producer.py
+++ b/tests/test_producer.py
@@ -689,7 +689,7 @@ def _fake_publisher(stream: str, send_publish_frame) -> _Publisher:
         reference=None,
         stream=stream,
         sequence=utils.MonotonicSeq(),
-        client=SimpleNamespace(frame_max=1024 * 1024, send_publish_frame=send_publish_frame),  # type: ignore
+        client=SimpleNamespace(frame_max=1024 * 1024, send_publish_frame=send_publish_frame),  #type:ignore
     )
 
 

--- a/tests/test_producer.py
+++ b/tests/test_producer.py
@@ -5,12 +5,14 @@ import asyncio
 import logging
 import time
 from functools import partial
+from types import SimpleNamespace
 
 import pytest
 
 from rstream import (
     AMQPMessage,
     CompressionType,
+    ConfirmationStatus,
     Consumer,
     OnClosedErrorInfo,
     Producer,
@@ -20,9 +22,12 @@ from rstream import (
     SuperStreamProducer,
     amqp_decoder,
     exceptions,
+    schema,
+    utils,
 )
 from rstream.client import Client
 from rstream.encoding import encode_publish
+from rstream.producer import _MessageNotification, _Publisher
 
 from .util import (
     http_api_delete_connection_and_check,
@@ -608,6 +613,151 @@ async def test_producer_connection_broke(stream: str, consumer: Consumer) -> Non
     await wait_for(lambda: len(streams_disconnected) == 1, 5, 1)
     await wait_for(lambda: len(captured) == 500, 5, 1)
     await producer_broke.close()
+
+
+async def test_producer_reconnects_concurrently_for_streams_sharing_a_connection(monkeypatch) -> None:
+    # Streams that share a broken connection must all start recovering at once.
+    # If recovery were awaited sequentially, stream N+1 wouldn't even start
+    # recovering until stream N's backoff/reconnect attempt (which can take
+    # several seconds) finishes, so streams sharing a connection could be
+    # starved of reconnection if the connection keeps getting killed faster
+    # than the serialized chain of recoveries can complete.
+    producer = Producer("localhost", username="guest", password="guest")
+
+    shared_streams = ["shared-stream-0", "shared-stream-1", "shared-stream-2"]
+    recovery_start_times: dict[str, float] = {}
+    recovery_delay = 0.3
+
+    async def fake_maybe_restart_producer(reason: str, stream: str) -> None:
+        recovery_start_times[stream] = time.monotonic()
+        await asyncio.sleep(recovery_delay)
+
+    monkeypatch.setattr(producer, "maybe_restart_producer", fake_maybe_restart_producer)
+
+    handler_start = time.monotonic()
+    await producer._on_connection_closed(
+        OnClosedErrorInfo(reason="Connection Closed", streams=shared_streams)
+    )
+    handler_duration = time.monotonic() - handler_start
+
+    # the handler must return almost immediately: recovery is scheduled in the
+    # background instead of being awaited one stream at a time
+    assert handler_duration < recovery_delay
+
+    await wait_for(lambda: len(recovery_start_times) == len(shared_streams), 2, 0.05)
+
+    # all streams must start recovering together, not one after another
+    spread = max(recovery_start_times.values()) - min(recovery_start_times.values())
+    assert spread < recovery_delay
+
+
+async def test_fail_pending_confirmations_reports_lost_messages_on_disconnect() -> None:
+    # Messages that were sent (registered in _waiting_for_confirm) but whose
+    # PublishConfirm/PublishError frame never arrives because the connection
+    # dropped must still be reported to the caller as failed. Otherwise
+    # on_publish_confirm is never called for them: they are neither confirmed
+    # nor counted as errors, they just vanish, so confirmed_count silently
+    # falls behind the number of messages actually sent.
+    producer = Producer("localhost", username="guest", password="guest")
+
+    confirmed: list[ConfirmationStatus] = []
+
+    async def on_publish_confirm(confirmation: ConfirmationStatus) -> None:
+        confirmed.append(confirmation)
+
+    publisher_id = 0
+    future: asyncio.Future = asyncio.get_event_loop().create_future()
+    producer._waiting_for_confirm[publisher_id][on_publish_confirm] = {1, 2, 3}
+    producer._waiting_for_confirm[publisher_id][future] = {4, 5}
+
+    await producer._fail_pending_confirmations(publisher_id, "Connection Closed")
+
+    assert {c.message_id for c in confirmed} == {1, 2, 3}
+    assert all(c.is_confirmed is False for c in confirmed)
+
+    assert future.done()
+    with pytest.raises(exceptions.ServerError):
+        future.result()
+
+    # the entry must be cleared so a stale publisher_id can't leak state
+    assert publisher_id not in producer._waiting_for_confirm
+
+
+def _fake_publisher(stream: str, send_publish_frame) -> _Publisher:
+    return _Publisher(
+        id=0,
+        reference=None,
+        stream=stream,
+        sequence=utils.MonotonicSeq(),
+        client=SimpleNamespace(frame_max=1024 * 1024, send_publish_frame=send_publish_frame),
+    )
+
+
+async def test_send_batch_does_not_drop_confirmation_racing_with_send(monkeypatch) -> None:
+    # Regression test: on a fast/stable connection the broker can send back
+    # PublishConfirm as soon as send_publish_frame is awaited, before this
+    # coroutine gets a chance to run again. Confirmation tracking must be
+    # registered in _waiting_for_confirm *before* the frame is sent, otherwise
+    # the incoming PublishConfirm finds nothing to match and the callback is
+    # silently never invoked even though the broker confirmed the message.
+    producer = Producer("localhost", username="guest", password="guest")
+    stream = "race-stream"
+
+    async def fake_send_publish_frame(frame, version=1):
+        publishing_ids = [m.publishing_id for m in frame.messages]
+        await producer._on_publish_confirm(
+            schema.PublishConfirm(publisher_id=frame.publisher_id, publishing_ids=publishing_ids),
+            publisher,
+        )
+
+    publisher = _fake_publisher(stream, fake_send_publish_frame)
+
+    async def fake_get_or_create_publisher(stream_name, publisher_name=None):
+        return publisher
+
+    monkeypatch.setattr(producer, "_get_or_create_publisher", fake_get_or_create_publisher)
+
+    confirmed: list[ConfirmationStatus] = []
+
+    async def on_publish_confirm(confirmation: ConfirmationStatus) -> None:
+        confirmed.append(confirmation)
+
+    await producer._send_batch(stream, [b"hello"], callback=on_publish_confirm, sync=False)
+
+    assert len(confirmed) == 1
+    assert confirmed[0].is_confirmed is True
+
+
+async def test_send_async_does_not_drop_confirmation_racing_with_send(monkeypatch) -> None:
+    # Same race as above but for the buffered/async path used by
+    # Producer.send(), which is what BestPracticesClient.py relies on.
+    producer = Producer("localhost", username="guest", password="guest")
+    stream = "race-stream-async"
+
+    async def fake_send_publish_frame(frame, version=1):
+        publishing_ids = [m.publishing_id for m in frame.messages]
+        await producer._on_publish_confirm(
+            schema.PublishConfirm(publisher_id=frame.publisher_id, publishing_ids=publishing_ids),
+            publisher,
+        )
+
+    publisher = _fake_publisher(stream, fake_send_publish_frame)
+
+    async def fake_get_or_create_publisher(stream_name, publisher_name=None):
+        return publisher
+
+    monkeypatch.setattr(producer, "_get_or_create_publisher", fake_get_or_create_publisher)
+
+    confirmed: list[ConfirmationStatus] = []
+
+    async def on_publish_confirm(confirmation: ConfirmationStatus) -> None:
+        confirmed.append(confirmation)
+
+    batch = [_MessageNotification(entry=b"hello", callback=on_publish_confirm) for _ in range(50)]
+    await producer._send_batch_async(stream, batch)
+
+    assert len(confirmed) == 50
+    assert all(c.is_confirmed is True for c in confirmed)
 
 
 # flaky test


### PR DESCRIPTION
… confirmations

Producer reconnection and confirmation tracking had three related bugs that caused confirmed_count to fall behind the number of messages actually sent, even when the server confirmed every message correctly:

- _on_connection_closed/_on_metadata_update awaited maybe_restart_producer() sequentially per stream instead of scheduling it concurrently, so streams sharing a connection could starve each other's reconnection when kills happened faster than the serialized backoff chain could complete.
- When a publisher was torn down after a disconnect, its pending _waiting_for_confirm entries were discarded without notifying callers, so in-flight messages were silently neither confirmed nor errored.
- _send_batch/_send_batch_async registered publishing_ids in _waiting_for_confirm *after* awaiting send_publish_frame, so on a fast, stable connection the broker's PublishConfirm could arrive and be processed before the ids were registered, dropping the confirmation permanently.